### PR TITLE
Fix bug in handling of HTML image size

### DIFF
--- a/UI/src/com/sun/lwuit/html/DefaultHTMLCallback.java
+++ b/UI/src/com/sun/lwuit/html/DefaultHTMLCallback.java
@@ -123,5 +123,12 @@ public class DefaultHTMLCallback implements HTMLCallback {
     public void dataChanged(int type, int index, HTMLComponent htmlC, TextField textField, HTMLElement element) {
         // do nothing
     }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public void mediaPlayRequested(int type, int op, HTMLComponent htmlC, String src, HTMLElement mediaElement) {
+        //do nothing
+    }
 
 }

--- a/UI/src/com/sun/lwuit/html/HTMLCallback.java
+++ b/UI/src/com/sun/lwuit/html/HTMLCallback.java
@@ -155,6 +155,16 @@ public interface HTMLCallback extends ParserCallback,CSSParserCallback {
     public static int LINK_FORBIDDEN = 2;
 
 
+    public static int MEDIA_AUDIO = 1;
+    
+    public static int MEDIA_VIDEO = 2;
+    
+    public static int MEDIA_PLAY = 5;
+    
+    public static int MEDIA_PAUSE = 6;
+    
+    public static int MEDIA_STOP = 7;
+    
     //////////////////////////////////
     // Interface methods            //
     //////////////////////////////////
@@ -284,4 +294,16 @@ public interface HTMLCallback extends ParserCallback,CSSParserCallback {
      */
     public void dataChanged(int type, int index, HTMLComponent htmlC, TextField textField, HTMLElement element);
 
+    /**
+     * Called when an media element (e.g. audio or video tag) is selected
+     * 
+     * @param type AUDIO or VIDEO
+     * @param op - play, pause, stop
+     * @param htmlC
+     * @param src
+     * @param mediaElement 
+     */
+    public void mediaPlayRequested(int type, int op, HTMLComponent htmlC, String src, HTMLElement mediaElement);
+    
+    
 }

--- a/UI/src/com/sun/lwuit/html/HTMLComponent.java
+++ b/UI/src/com/sun/lwuit/html/HTMLComponent.java
@@ -43,6 +43,7 @@ import com.sun.lwuit.events.ActionEvent;
 import com.sun.lwuit.events.ActionListener;
 import com.sun.lwuit.geom.Dimension;
 import com.sun.lwuit.geom.Rectangle;
+import com.sun.lwuit.impl.LWUITImplementation;
 import com.sun.lwuit.layouts.BorderLayout;
 import com.sun.lwuit.layouts.BoxLayout;
 import com.sun.lwuit.layouts.FlowLayout;
@@ -267,6 +268,13 @@ public class HTMLComponent extends Container implements ActionListener,AsyncDocu
     static private final int DEFAULT_LINK_COLOR = 0x0000ff;
 
 
+    /**
+     * Space reservation for images where one of height or width is left unspecified
+     * e.g. where width is specified but height is not
+     * Array : Top, Left, Bottom, Right
+     */
+    protected int[] imgReservationSpace = null;
+    
     // Document colors
     private int bgColor=DEFAULT_BGCOLOR;
     private int textColor=DEFAULT_TEXT_COLOR;
@@ -2251,6 +2259,13 @@ public class HTMLComponent extends Container implements ActionListener,AsyncDocu
 
             String imageUrl = imgElement.getAttributeById(HTMLElement.ATTR_SRC);
             Label imgLabel=null;
+            
+            if(imgReservationSpace == null) {
+                Style s = UIManager.getInstance().getComponentStyle("Label");
+                imgReservationSpace = new int[] { s.getPadding(TOP), 
+                    s.getPadding(LEFT), s.getPadding(BOTTOM), s.getPadding(RIGHT)};
+            }
+            
             if (imageUrl!=null) {
 
                 String alignStr=imgElement.getAttributeById(HTMLElement.ATTR_ALIGN);
@@ -2316,15 +2331,15 @@ public class HTMLComponent extends Container implements ActionListener,AsyncDocu
 
                     
                     if ((iWidth!=0) || (iHeight!=0)) { // reserve space while loading image if either width or height are specified, otherwise we don't know how much to reserve
-                        iWidth+=imgLabel.getStyle().getPadding(Component.LEFT)+imgLabel.getStyle().getPadding(Component.RIGHT);
-                        iHeight+=imgLabel.getStyle().getPadding(Component.TOP)+imgLabel.getStyle().getPadding(Component.BOTTOM);
+                        iWidth+=imgReservationSpace[LEFT] + imgReservationSpace[RIGHT];
+                        iHeight+=imgReservationSpace[TOP] + imgReservationSpace[BOTTOM];
                         imgLabel.setPreferredSize(new Dimension(iWidth,iHeight));
                     } else { // If no space is reserved, make a minimal text, otherwise LWUIT won't calculate the size right after the image loads
                         if ((imgLabel.getText()==null) || (imgLabel.getText().equals(""))) {
                             imgLabel.setText(" ");
                         }
                     }
-
+                    
                     // It is important that the padding of the image component itself will be all 0
                     // This is because when the image is loaded, its preferred size is checked to see if its width/height were preset by the width/height attribute
                     imgLabel.getSelectedStyle().setPadding(0,0,0,0);

--- a/UI/src/com/sun/lwuit/html/HTMLComponent.java
+++ b/UI/src/com/sun/lwuit/html/HTMLComponent.java
@@ -275,6 +275,22 @@ public class HTMLComponent extends Container implements ActionListener,AsyncDocu
      */
     protected int[] imgReservationSpace = null;
     
+    /**
+     * Indicate that the images should be constrained to fit within the available
+     * component width
+     */
+    public static final int IMG_CONSTRAIN_WIDTH = 1;
+    
+    /**
+     * Indicate that the images should be constrained to fit within the avialable
+     */
+    public static final int IMG_CONSTRAIN_HEIGHT = 2;
+    
+    /**
+     * The image constraint policy for this HTML component
+     */
+    protected int imgConstraints = 0;
+    
     // Document colors
     private int bgColor=DEFAULT_BGCOLOR;
     private int textColor=DEFAULT_TEXT_COLOR;
@@ -656,6 +672,33 @@ public class HTMLComponent extends Container implements ActionListener,AsyncDocu
         if (SUPPORT_CSS) { // If not supporting CSS, the loadCSS flag is locked on false
             loadCSS=!ignore;
         }
+    }
+    
+    /**
+     * A lightweight alternative to CSS and 'Responsive' design: allow constraining
+     * images to the available width and/or height of the screen.  When set
+     * images will be resized in proportion to fit the width and/or height.
+     * 
+     * @param constraints A bitmask flag that can include IMG_CONSTRAIN_WIDTH
+     * and IMG_CONSTRAIN_HEIGHT e.g. IMG_CONSTRAIN_WIDTH | IMG_CONSTRAIN_HEIGHT
+     * to constrain both.
+     * 
+     * @see HTMLComponent#IMG_CONSTRAIN_WIDTH
+     * @see HTMLComponent#IMG_CONSTRAIN_HEIGHT
+     */
+    public void setImageConstrainPolicy(int constraints) {
+        this.imgConstraints = constraints;
+    }
+    
+    /**
+     * Get the current image constraint policy
+     * 
+     * @see HTMLComponent#setImageConstrainPolicy(int) 
+     * 
+     * @return The current image constraint policy
+     */
+    public int getImageConstrainPolicy() {
+        return this.imgConstraints;
     }
 
     /**

--- a/UI/src/com/sun/lwuit/html/HTMLComponent.java
+++ b/UI/src/com/sun/lwuit/html/HTMLComponent.java
@@ -1179,6 +1179,7 @@ public class HTMLComponent extends Container implements ActionListener,AsyncDocu
                         //if ( ((!showImages) || (threadQueue.getQueueSize()==0)) {
                         if (threadQueue.getQueueSize()==0) {
                             setPageStatus(HTMLCallback.STATUS_COMPLETED);
+                            checkAutoplay();
                         } else {
                             threadQueue.startRunning();
                         }

--- a/UI/src/com/sun/lwuit/html/HTMLComponent.java
+++ b/UI/src/com/sun/lwuit/html/HTMLComponent.java
@@ -1174,7 +1174,6 @@ public class HTMLComponent extends Container implements ActionListener,AsyncDocu
 
                         if (threadQueue.getCSSCount()==-1) {
                             displayPage();
-                            checkAutoplay();
                         }
                         //if ( ((!showImages) || (threadQueue.getQueueSize()==0)) {
                         if (threadQueue.getQueueSize()==0) {

--- a/UI/src/com/sun/lwuit/html/HTMLElement.java
+++ b/UI/src/com/sun/lwuit/html/HTMLElement.java
@@ -155,10 +155,16 @@ public class HTMLElement extends Element {
  public static final int TAG_TBODY = 79;
  public static final int TAG_TFOOT = 80;
 
+ //Media tags (not really HTML4 - but can be dealt with
+ public static final int TAG_AUDIO = 81;
+ public static final int TAG_VIDEO = 82;
+ 
  //Text nodes (not an actual tag - text segments are added by the parser as the 'text' tag
- public static final int TAG_TEXT = 81;
+ public static final int TAG_TEXT = 83;
+ 
+ 
 
- private static int LAST_TAG_INDEX = HTMLComponent.PROCESS_HTML_MP1_ONLY?TAG_FIELDSET:TAG_TFOOT; // In any case we exclude TAG_TEXT, which is given only on text element creation
+ private static int LAST_TAG_INDEX = HTMLComponent.PROCESS_HTML_MP1_ONLY?TAG_FIELDSET:TAG_VIDEO; // In any case we exclude TAG_TEXT, which is given only on text element creation
 
 
 /**
@@ -179,7 +185,9 @@ static final String[] TAG_NAMES = {
     ,"hr","optgroup","style","b","i","big","small","fieldset"
     //html4 tags
     ,"u","font","del","ins","tt","basefont","menu","s","strike","center","dir","map","area","legend","sub","sup","noscript","noframes"
-    ,"thead","tbody","tfoot"
+    ,"thead","tbody","tfoot",
+    //media elements
+    "audio","video"
     ,"text"
 };
 
@@ -269,6 +277,10 @@ static final String[] TAG_NAMES = {
  public static final int ATTR_DISABLED = 71;
  public static final int ATTR_READONLY = 72;
  public static final int ATTR_ISMAP = 73;
+ 
+ //Media tags
+ public static final int ATTR_AUTOPLAY = 74;
+ public static final int ATTR_CONTROLS = 75;
 
   /**
   * Defines the allowed attribute names, these are specified according to the ATTR_* constants numbering.
@@ -282,7 +294,7 @@ static final String[] TAG_NAMES = {
     "cols","rows","dir","border",
     "color","face","shape","coords","usemap",
     "lang","cellspacing","cellpadding","frame","rules",
-    "disabled","readonly","ismap"
+    "disabled","readonly","ismap", "autoplay", "controls"
  };
 
  /**
@@ -603,8 +615,18 @@ static final String[] TAG_NAMES = {
         ATTR_ALIGN,
         ATTR_VALIGN
      }, //TAG_TFOOT = 80;
-     {}, //TEXT = 81;
-
+     {
+         ATTR_AUTOPLAY,
+         ATTR_SRC,
+         ATTR_CONTROLS
+     },//TAG_AUDIO = 81
+     {
+         ATTR_AUTOPLAY,
+         ATTR_SRC,
+         ATTR_CONTROLS
+     },//TAG_VIDEO = 82
+     {} //TEXT = 83;
+     
  };
 
 
@@ -723,6 +745,8 @@ static final String[] TAG_NAMES = {
     TYPE_NMTOKEN, //ATTR_DISABLED = 71;
     TYPE_NMTOKEN, //ATTR_READONLY = 72;
     TYPE_NMTOKEN, //ATTR_ISMAP = 73;
+    TYPE_CDATA,//ATTR_AUTOPLAY = 74
+    TYPE_CDATA //ATTR_CONTROLS = 57
  };
 
 /**

--- a/UI/src/com/sun/lwuit/html/ResourceThreadQueue.java
+++ b/UI/src/com/sun/lwuit/html/ResourceThreadQueue.java
@@ -556,7 +556,23 @@ class ResourceThreadQueue {
                     width=img.getWidth()*height/img.getHeight();
                 }
             }
-
+            
+            int availableSize = htmlC.getWidth();
+            boolean constrain = 
+                (htmlC.imgConstraints & HTMLComponent.IMG_CONSTRAIN_WIDTH) == HTMLComponent.IMG_CONSTRAIN_WIDTH;
+            if(constrain & availableSize < width) {
+                height = height * availableSize/width;
+                width = availableSize;
+            }
+            
+            availableSize = htmlC.getParent() != null ? htmlC.getParent().getHeight() : Display.getInstance().getDisplayHeight();
+            constrain = 
+                (htmlC.imgConstraints & HTMLComponent.IMG_CONSTRAIN_HEIGHT) == HTMLComponent.IMG_CONSTRAIN_HEIGHT;
+            if(constrain & availableSize < height) {
+                width = width * availableSize/height;
+                height = availableSize;
+            }
+            
             if (width!=0) { // if any of width or height were not 0, the other one was set to non-zero above, so this check suffices
                 img=img.scaled(width, height);
                 width+=htmlC.imgReservationSpace[Component.LEFT]+htmlC.imgReservationSpace[Component.RIGHT];

--- a/UI/src/com/sun/lwuit/html/ResourceThreadQueue.java
+++ b/UI/src/com/sun/lwuit/html/ResourceThreadQueue.java
@@ -544,8 +544,8 @@ class ResourceThreadQueue {
             label.setText(""); // remove the alternate text (important to do here before checking the width/height)
 
             // Was set in HTMLComponent.handleImage if the width/height attributes were in the tag
-            int width=label.getPreferredW()-label.getStyle().getPadding(Component.LEFT)-label.getStyle().getPadding(Component.RIGHT);
-            int height=label.getPreferredH()-label.getStyle().getPadding(Component.TOP)-label.getStyle().getPadding(Component.BOTTOM);
+            int width=label.getPreferredW()-htmlC.imgReservationSpace[Component.LEFT]-htmlC.imgReservationSpace[Component.RIGHT];
+            int height=label.getPreferredH()-htmlC.imgReservationSpace[Component.TOP]-htmlC.imgReservationSpace[Component.BOTTOM];
 
             if (width!=0) {
                 if (height==0) { // If only width was specified, height should be calculated so the image keeps its aspect ratio
@@ -559,8 +559,8 @@ class ResourceThreadQueue {
 
             if (width!=0) { // if any of width or height were not 0, the other one was set to non-zero above, so this check suffices
                 img=img.scaled(width, height);
-                width+=label.getStyle().getPadding(Component.LEFT)+label.getStyle().getPadding(Component.RIGHT);
-                height+=label.getStyle().getPadding(Component.TOP)+label.getStyle().getPadding(Component.BOTTOM);
+                width+=htmlC.imgReservationSpace[Component.LEFT]+htmlC.imgReservationSpace[Component.RIGHT];
+                height+=htmlC.imgReservationSpace[Component.TOP]+htmlC.imgReservationSpace[Component.BOTTOM];
                 label.setPreferredSize(new Dimension(width,height));
             }
 

--- a/UI/src/com/sun/lwuit/html/ResourceThreadQueue.java
+++ b/UI/src/com/sun/lwuit/html/ResourceThreadQueue.java
@@ -290,6 +290,7 @@ class ResourceThreadQueue {
         if (threadCount==0) {
             if (images.size()==0) {
                 htmlC.setPageStatus(HTMLCallback.STATUS_COMPLETED);
+                htmlC.checkAutoplay();
             } else {
                 startRunningImages();
             }


### PR DESCRIPTION
When the HTML component has an image where either the width or height is specified it should calculate the remaining dimension.  This logic didn't quite work because in HTMLComponent on Line 2334 it's adding to the width based on the component style padding (e.g. unselected style).  On line 2346 it's setting the style in that padding to 0.  In ResourceThreadQueue it's then subtracting the style padding to see if the width or height was unspecified; but the style padding was changed; so even if the width/height was unspecified it doesn't calculate out as it seems to have been designed to.

I'm not sure if anyone is maintaining this or can merge things anymore these days.  But I'll put this out here anyway.

Thanks,

-Mike